### PR TITLE
Move securities gem requirement to data_spec.rb

### DIFF
--- a/lib/indicators.rb
+++ b/lib/indicators.rb
@@ -1,5 +1,4 @@
 require "indicators/version"
-require "securities"
 require "indicators/data.rb"
 require "indicators/parser.rb"
 require "indicators/main.rb"

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'securities'
 
 describe Indicators::Data do
 


### PR DESCRIPTION
As brought up in https://github.com/Nedomas/indicators/issues/3 - the securities gem is only used in tests and should not be required for general uses of the indicators gem.
